### PR TITLE
Settings: Make proximity wake string more accurate

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -292,7 +292,7 @@
 
     <!-- Proximity wake -->
     <string name="proximity_wake_title">Prevent accidental wake-up</string>
-    <string name="proximity_wake_summary">Check the proximity sensor prior to waking up screen</string>
+    <string name="proximity_wake_summary">Check the proximity sensor prior to wake-ups triggered by gestures</string>
 
     <!-- High touch sensitivity -->
     <string name="high_touch_sensitivity_title">High touch sensitivity</string>


### PR DESCRIPTION
We also check the proximity sensor for gesture-activated wake-ups,
such as tap to wake.

Change-Id: I4e73a8d9b116e49fa168c1a4a457f55ff3885aea