### PR TITLE
SimPreferenceDialog: Set onDismiss() listener to finish the activity

### DIFF
--- a/src/com/android/settings/sim/SimPreferenceDialog.java
+++ b/src/com/android/settings/sim/SimPreferenceDialog.java
@@ -167,7 +167,6 @@ public class SimPreferenceDialog extends Activity {
                 mSubInfoRecord.setIconTint(tint);
                 mSubscriptionManager.setIconTint(tint, subscriptionId);
                 dialog.dismiss();
-                finish();
             }
         });
 
@@ -175,6 +174,12 @@ public class SimPreferenceDialog extends Activity {
             @Override
             public void onClick(DialogInterface dialog, int whichButton) {
                 dialog.dismiss();
+            }
+        });
+
+        mBuilder.setOnDismissListener(new DialogInterface.OnDismissListener() {
+            @Override
+            public void onDismiss(DialogInterface dialog) {
                 finish();
             }
         });


### PR DESCRIPTION
* Fixes gray tint after escaping from a dialog using
  back key or by touching outside of it.

Change-Id: Ie17059746809e8432be6a4705eb03d0fa21f1442