### PR TITLE
SoundSettings: Prevent NPE due to linked volumes change

### DIFF
--- a/src/com/android/settings/notification/SoundSettings.java
+++ b/src/com/android/settings/notification/SoundSettings.java
@@ -275,6 +275,7 @@ public class SoundSettings extends SettingsPreferenceFragment implements Indexab
     }
 
     private void updateRingOrNotificationPreference() {
+        if (mRingOrNotificationPreference == null) return;
         mRingOrNotificationPreference.showIcon(mSuppressor != null
                 ? com.android.internal.R.drawable.ic_audio_ring_notif_mute
                 : mRingerMode == AudioManager.RINGER_MODE_VIBRATE || wasRingerModeVibrate()


### PR DESCRIPTION
In AOSP, mRingOrNotificationPreference can never be null.

However, ever since the linked notification volumes change
in commit 6430dbd2d2f89c45e35750a4923f10f1b8bd839d, there is a
possibility that mRingOrNotificationPreference is null,
causing an NPE when calling showIcon() on it.

Add a null check to prevent that.

Change-Id: I8d7231f50fc1f04acdc706e2d2c775bed7803fca