### PR TITLE
Disabling the activate button when paused

### DIFF
--- a/src/com/android/settings/DeviceAdminAdd.java
+++ b/src/com/android/settings/DeviceAdminAdd.java
@@ -16,6 +16,8 @@
 
 package com.android.settings;
 
+import static android.view.WindowManager.LayoutParams.PRIVATE_FLAG_HIDE_NON_SYSTEM_OVERLAY_WINDOWS;
+
 import android.app.Activity;
 import android.app.ActivityManagerNative;
 import android.app.AlertDialog;
@@ -88,7 +90,6 @@ public class DeviceAdminAdd extends Activity {
     Handler mHandler;
 
     DevicePolicyManager mDPM;
-    AppOpsManager mAppOps;
     DeviceAdminInfo mDeviceAdmin;
     CharSequence mAddMsgText;
     String mProfileOwnerName;
@@ -113,19 +114,17 @@ public class DeviceAdminAdd extends Activity {
     boolean mWaitingForRemoveMsg;
     boolean mAddingProfileOwner;
     boolean mAdminPoliciesInitialized;
-    int mCurSysAppOpMode;
-    int mCurToastAppOpMode;
 
     boolean mIsCalledFromSupportDialog = false;
 
     @Override
     protected void onCreate(Bundle icicle) {
         super.onCreate(icicle);
+        getWindow().addPrivateFlags(PRIVATE_FLAG_HIDE_NON_SYSTEM_OVERLAY_WINDOWS);
 
         mHandler = new Handler(getMainLooper());
 
         mDPM = (DevicePolicyManager)getSystemService(Context.DEVICE_POLICY_SERVICE);
-        mAppOps = (AppOpsManager)getSystemService(Context.APP_OPS_SERVICE);
         PackageManager packageManager = getPackageManager();
 
         if ((getIntent().getFlags()&Intent.FLAG_ACTIVITY_NEW_TASK) != 0) {
@@ -447,24 +446,14 @@ public class DeviceAdminAdd extends Activity {
     @Override
     protected void onResume() {
         super.onResume();
+        mActionButton.setEnabled(true);
         updateInterface();
-        // As long as we are running, don't let this admin overlay stuff on top of the screen.
-        final int uid = mDeviceAdmin.getActivityInfo().applicationInfo.uid;
-        final String pkg = mDeviceAdmin.getActivityInfo().applicationInfo.packageName;
-        mCurSysAppOpMode = mAppOps.checkOp(AppOpsManager.OP_SYSTEM_ALERT_WINDOW, uid, pkg);
-        mCurToastAppOpMode = mAppOps.checkOp(AppOpsManager.OP_TOAST_WINDOW, uid, pkg);
-        mAppOps.setMode(AppOpsManager.OP_SYSTEM_ALERT_WINDOW, uid, pkg, AppOpsManager.MODE_IGNORED);
-        mAppOps.setMode(AppOpsManager.OP_TOAST_WINDOW, uid, pkg, AppOpsManager.MODE_IGNORED);
     }
 
     @Override
     protected void onPause() {
         super.onPause();
-        // As long as we are running, don't let this admin overlay stuff on top of the screen.
-        final int uid = mDeviceAdmin.getActivityInfo().applicationInfo.uid;
-        final String pkg = mDeviceAdmin.getActivityInfo().applicationInfo.packageName;
-        mAppOps.setMode(AppOpsManager.OP_SYSTEM_ALERT_WINDOW, uid, pkg, mCurSysAppOpMode);
-        mAppOps.setMode(AppOpsManager.OP_TOAST_WINDOW, uid, pkg, mCurToastAppOpMode);
+        mActionButton.setEnabled(false);
         try {
             ActivityManagerNative.getDefault().resumeAppSwitches();
         } catch (RemoteException e) {


### PR DESCRIPTION
This revises the previous attempt to drop taps when another window is
obscuring the device admin details. Any system alert windows or toasts
are disabled when the activity is in focus, otherwise the button is
disabled so no floating activities can obscure it and delegate taps back
to the security sensitive "Activate" button.

Test: CtsVerifier -> Device Administration -> Device Admin Tapjacking Test

Bug: 35056974
Change-Id: I292a44e713ea4a4b0305ca3b3b21f1c82fd73c2b
Merged-In: I292a44e713ea4a4b0305ca3b3b21f1c82fd73c2b
(cherry picked from commit 8e08a9bb715ff6a6b6bfa9556c3666a10f87053a)