### PR TITLE
Settings: Correct german translation for 1 registered fingerprint

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -337,7 +337,7 @@
     <string name="fingerprint_enable_keyguard_toggle_title" msgid="5078060939636911795">"Displaysperre"</string>
     <plurals name="security_settings_fingerprint_preference_summary" formatted="false" msgid="624961700033979880">
       <item quantity="other"><xliff:g id="COUNT_1">%1$d</xliff:g> Fingerabdrücke eingerichtet</item>
-      <item quantity="one"><xliff:g id="COUNT_0">%1$d</xliff:g> Fingerabdrücke eingerichtet</item>
+      <item quantity="one"><xliff:g id="COUNT_0">%1$d</xliff:g> Fingerabdruck eingerichtet</item>
     </plurals>
     <string name="security_settings_fingerprint_preference_summary_none" msgid="1507739327565151923"></string>
     <string name="security_settings_fingerprint_enroll_introduction_title" msgid="3201556857492526098">"Mit Fingerabdruck entsperren"</string>


### PR DESCRIPTION
* It's "1 Fingerabdruck", not "1 Fingerabdrücke" (thats plural)

Change-Id: I3273ad92eb8d8c9dceaaa8c385a6da86bfe2d5f8